### PR TITLE
fix(ci): snapshot artifacts list before SHA256 to avoid Out-File race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,16 @@ jobs:
         shell: pwsh
         working-directory: artifacts
         run: |
-          Get-ChildItem -File | ForEach-Object {
-            $hash = (Get-FileHash $_.Name -Algorithm SHA256).Hash
-            "$hash  $($_.Name)"
-          } | Out-File -Encoding ascii SHA256SUMS.txt
+          # Snapshot the file list before opening the output file. The previous
+          # streamed pipeline raced with Out-File: Get-ChildItem is lazy, so it
+          # re-enumerated SHA256SUMS.txt while it was still locked for writing.
+          $files = Get-ChildItem -File -Exclude SHA256SUMS.txt |
+                   Select-Object -ExpandProperty Name
+          $lines = foreach ($f in $files) {
+            $hash = (Get-FileHash $f -Algorithm SHA256).Hash
+            "$hash  $f"
+          }
+          $lines | Out-File -Encoding ascii SHA256SUMS.txt
 
           Write-Host "`nSHA256SUMS.txt:"
           Get-Content SHA256SUMS.txt


### PR DESCRIPTION
## Summary

The Windows SHA256 step in the release pipeline has been failing every release since v1.0.0-rc1 — including v1.1.0 just now (Linux build green, Windows build red on the SHA256 step, release job skipped).

Root cause: the streamed PowerShell pipeline races with itself —

\`\`\`powershell
Get-ChildItem -File | ForEach-Object {
  \$hash = (Get-FileHash \$_.Name -Algorithm SHA256).Hash
  "\$hash  \$(\$_.Name)"
} | Out-File -Encoding ascii SHA256SUMS.txt
\`\`\`

\`Get-ChildItem\` is lazy, so as items stream through, it eventually re-enumerates \`SHA256SUMS.txt\` itself while \`Out-File\` still holds the write lock. \`Get-FileHash\` then errors with: *The process cannot access the file 'SHA256SUMS.txt' because it is being used by another process.*

## Fix

Snapshot the file list into an array first, exclude \`SHA256SUMS.txt\` from the input, compute all hashes, then write the file in one shot.

The Linux SHA256 step already snapshots safely (explicit \`for f in *\` with a \`!= SHA256SUMS.txt\` guard) — only the Windows step needed fixing.

## Test plan

- [x] CI lint+test on this PR (Windows + Linux).
- [ ] Re-run the release pipeline against \`v1.1.0\` after merge — both build jobs and the release job should succeed; resulting \`SHA256SUMS.txt\` should contain hashes for every other artifact and not for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)