### PR TITLE
fix(ci): release: separate download dirs + combine checksums; bump v1.1 display strings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,30 +212,35 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Each build job uploads its own SHA256SUMS.txt. Download into separate
+      # directories so the second download doesn't overwrite the first; then
+      # combine into a single canonical SHA256SUMS.txt for the release.
       - name: Download Windows artifacts
         uses: actions/download-artifact@v4
         with:
           name: windows-build
-          path: artifacts
+          path: artifacts-win
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4
         with:
           name: linux-build
-          path: artifacts
+          path: artifacts-linux
 
-      # Both jobs upload a SHA256SUMS.txt; merge them into one combined file so the
-      # release has a single canonical checksum manifest.
-      - name: Merge checksum files
-        working-directory: artifacts
+      - name: Stage artifacts and combine checksums
         run: |
-          if compgen -G "SHA256SUMS*.txt" > /dev/null; then
-            cat SHA256SUMS*.txt > SHA256SUMS.combined.txt
-            rm -f SHA256SUMS.txt SHA256SUMS*.txt
-            mv SHA256SUMS.combined.txt SHA256SUMS.txt
-            echo "Combined SHA256SUMS.txt:"
-            cat SHA256SUMS.txt
-          fi
+          mkdir -p artifacts
+          # Copy every artifact except the per-platform SHA256SUMS.txt files.
+          find artifacts-win artifacts-linux -mindepth 1 -maxdepth 1 -type f \
+            ! -name 'SHA256SUMS.txt' -exec cp -t artifacts/ {} +
+          # Combine the per-platform manifests into one.
+          cat artifacts-win/SHA256SUMS.txt artifacts-linux/SHA256SUMS.txt \
+            > artifacts/SHA256SUMS.txt
+          echo "Combined SHA256SUMS.txt:"
+          cat artifacts/SHA256SUMS.txt
+          echo
+          echo "Final artifacts/:"
+          ls -lh artifacts/
 
       - name: Resolve tag
         id: tag

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ See `dofek.toml.example` for all options. Key settings:
 - `lhm.url` (default `http://localhost:8085`) — LHM web server address (only used as GPU fallback)
 - `[[plugins]]` — plugin definitions (name, command, args, enabled, timeout_ms)
 
-## Current Status (v1.0)
+## Current Status (v1.1)
 
 Trading-terminal layout with dual interface (TUI + Tauri GUI), candlestick CPU chart, area/horizon charts for GPU/MEM/NET, multi-GPU support, process categories (AI/DEV/WATCH), top ticker bar, compact bottom strip, plugin system with JSON-over-stdio protocol. Custom chart widgets use Buffer manipulation with half-block characters for 2x vertical resolution.
 

--- a/README-install.txt
+++ b/README-install.txt
@@ -1,26 +1,40 @@
-dofek v1.0 — Installation Notes
+dofek v1.1 — Installation Notes
 ================================
 
 Thanks for installing dofek.
 
-  - Launch GUI:   Start Menu → "dofek"
-  - Launch TUI:   open a terminal and run "dofek-tui" (or run dofek-tui.exe from this folder)
-  - Full manual:  open "manual.html" in this folder (or Start Menu → "dofek Manual")
-  - Press "?" inside either interface for the keybinding overlay.
+Launching
+---------
+Windows
+  - GUI:    Start Menu → "dofek"
+  - TUI:    open a terminal and run "dofek-tui" (or run dofek-tui.exe from
+            this folder)
+  - Manual: open "manual.html" in this folder (or Start Menu → "dofek Manual")
+
+Linux
+  - GUI:    application menu → "dofek"  (or run "dofek-gui" from a terminal)
+  - TUI:    "dofek-tui" from any terminal (installed to /usr/bin by .deb/.rpm;
+            extract from the .AppImage if needed)
+  - Manual: open "manual.html" from /usr/share/dofek/ or this folder
+
+Press "?" inside either interface for the keybinding overlay.
 
 Configuration
 -------------
 dofek looks for a config file in this order:
-  1. --config <path>                    (TUI only)
-  2. .\dofek.toml                       (current working directory)
-  3. %APPDATA%\dofek\dofek.toml         (recommended)
+  1. --config <path>                       (TUI only)
+  2. ./dofek.toml                          (current working directory)
+  3. user config directory:
+       Windows: %APPDATA%\dofek\dofek.toml
+       Linux:   ~/.config/dofek/dofek.toml
 
-See manual.html for the full option reference, or dofek.toml.example in the source repo.
+See manual.html for the full option reference, or dofek.toml.example in the
+source repo.
 
 Support
 -------
-  - Website:       https://dofek.dev
-  - Source:        https://github.com/AsafSaar/dofek
-  - Bugs:          https://github.com/AsafSaar/dofek/issues
+  - Website:  https://dofek.dev
+  - Source:   https://github.com/AsafSaar/dofek
+  - Bugs:     https://github.com/AsafSaar/dofek/issues
 
 MIT Licensed.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Most system monitors were designed before LLMs ran locally. They treat GPU as an
 <summary>ASCII layout reference</summary>
 
 ```
-dofek v1.0  CPU 9.7%  GPU 1.0%  VRAM 1700/16303MB  MEM 34.0%  TEMP 36C    BOULDER11  07:33:40
+dofek v1.1  CPU 9.7%  GPU 1.0%  VRAM 1700/16303MB  MEM 34.0%  TEMP 36C    BOULDER11  07:33:40
 -----------------------------------------------------------------------------------------------
  [CPU]  GPU  MEM  NET   CANDLE                                 PROCESSES        CPU [MEM] VRAM
  9.7% AMD Ryzen 7 7800X3D 8-Core - 16-Core    -- warn 80%      ALL  AI  DEV  WATCH    sort:MEM
@@ -86,7 +86,7 @@ Pre-built binaries are published on the [Releases page](https://github.com/AsafS
 
 > ⚠️ **Binaries are currently unsigned.** On Windows, SmartScreen may flag the installer (right-click → Properties → "Unblock"). On Linux, AppImages need `chmod +x` before running.
 
-Verify (Windows): `Get-FileHash .\dofek_1.0.0_x64_en-US.msi -Algorithm SHA256`
+Verify (Windows): `Get-FileHash .\dofek_1.1.0_x64_en-US.msi -Algorithm SHA256`
 Verify (Linux): `sha256sum -c SHA256SUMS.txt`
 
 ## Features

--- a/gui/docs/dofek-concept-v2.html
+++ b/gui/docs/dofek-concept-v2.html
@@ -214,7 +214,7 @@ html,body{background:var(--bg);color:var(--text);font-family:var(--font);font-si
 
 <!-- TOP BAR -->
 <div class="topbar">
-  <div class="logo">dofek <em>v0.7</em></div>
+  <div class="logo">dofek <em>v1.1</em></div>
   <div class="pills">
     <div class="pill cpu"><span class="lbl">CPU</span><span class="val" id="t-cpu">10.2%</span></div>
     <div class="pill gpu"><span class="lbl">GPU</span><span class="val" id="t-gpu">22.6%</span></div>

--- a/gui/frontend/index.html
+++ b/gui/frontend/index.html
@@ -303,7 +303,7 @@ body::after{content:'';position:fixed;top:0;left:0;right:0;bottom:0;pointer-even
 
 <!-- TOP BAR -->
 <div class="topbar">
-  <div class="logo">dofek <em>v1.0</em></div>
+  <div class="logo">dofek <em>v1.1</em></div>
   <div class="pills">
     <div class="pill cpu"><span class="lbl">CPU</span><span class="val" id="t-cpu">—</span></div>
     <div class="pill gpu"><span class="lbl">GPU</span><span class="val" id="t-gpu">—</span></div>
@@ -1871,7 +1871,7 @@ function showToast(msg){
 <!-- About overlay -->
 <div class="help-overlay" id="about-overlay">
   <div class="help-box" style="text-align:center;min-width:280px;">
-    <div style="font-size:24px;font-weight:700;color:var(--cpu);letter-spacing:.08em;margin-bottom:6px;">dofek <span style="font-size:14px;color:var(--text);font-weight:600;">v1.0</span></div>
+    <div style="font-size:24px;font-weight:700;color:var(--cpu);letter-spacing:.08em;margin-bottom:6px;">dofek <span style="font-size:14px;color:var(--text);font-weight:600;">v1.1</span></div>
     <div style="font-size:13px;color:var(--dim);margin-bottom:14px;">Terminal / GUI, AI-aware system monitor</div>
     <div style="display:flex;flex-direction:column;gap:5px;margin-bottom:12px;">
       <a href="https://dofek.dev" target="_blank" class="about-link" style="font-size:11px;">dofek.dev</a>

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -28,7 +28,7 @@ pub fn render(f: &mut Frame) {
         Line::from(""),
         Line::from(vec![
             Span::styled("dofek ", Style::default().fg(theme::CPU_COLOR).add_modifier(Modifier::BOLD)),
-            Span::styled("v1.0", Style::default().fg(theme::TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
+            Span::styled("v1.1", Style::default().fg(theme::TEXT_PRIMARY).add_modifier(Modifier::BOLD)),
         ]),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui/ticker.rs
+++ b/src/ui/ticker.rs
@@ -19,7 +19,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &App) {
 
     // Logo
     spans.push(Span::styled(" dofek", Style::default().fg(theme::CPU_COLOR).add_modifier(Modifier::BOLD)));
-    spans.push(Span::styled(" v1.0", Style::default().fg(theme::TEXT_DIM)));
+    spans.push(Span::styled(" v1.1", Style::default().fg(theme::TEXT_DIM)));
     spans.push(Span::styled(" │ ", Style::default().fg(theme::BORDER2)));
 
     // CPU pill

--- a/website/index.html
+++ b/website/index.html
@@ -11,19 +11,19 @@
 </script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="dofek — AI-aware system monitor for Windows. TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
+<meta name="description" content="dofek — AI-aware system monitor for Windows and Linux. TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
 <meta name="theme-color" content="#060810">
 <meta name="google-site-verification" content="REPLACE_WITH_VERIFICATION_CODE">
 <link rel="canonical" href="https://dofek.dev/">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <meta property="og:title" content="dofek — system monitor for the AI era">
-<meta property="og:description" content="AI-aware system monitor for Windows — TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
+<meta property="og:description" content="AI-aware system monitor for Windows and Linux — TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://dofek.dev/">
 <meta property="og:image" content="https://dofek.dev/tui-screenshot.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="dofek — system monitor for the AI era">
-<meta name="twitter:description" content="AI-aware system monitor for Windows — TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
+<meta name="twitter:description" content="AI-aware system monitor for Windows and Linux — TUI and desktop app. VRAM per process, candlestick CPU charts, AI workload detection.">
 <meta name="twitter:image" content="https://dofek.dev/tui-screenshot.png">
 <title>dofek — system monitor for the AI era</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -522,14 +522,14 @@ footer {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "dofek",
-  "description": "AI-aware system monitor for Windows. TUI and desktop app with VRAM per process, candlestick CPU charts, and AI workload detection.",
+  "description": "AI-aware system monitor for Windows and Linux. TUI and desktop app with VRAM per process, candlestick CPU charts, and AI workload detection.",
   "url": "https://dofek.dev",
   "applicationCategory": "DeveloperApplication",
-  "operatingSystem": "Windows 10, Windows 11",
+  "operatingSystem": "Windows 10, Windows 11, Linux",
   "license": "https://opensource.org/licenses/MIT",
   "programmingLanguage": "Rust",
   "downloadUrl": "https://github.com/AsafSaar/dofek/releases",
-  "softwareVersion": "0.8",
+  "softwareVersion": "1.1",
   "offers": {
     "@type": "Offer",
     "price": "0",
@@ -547,7 +547,7 @@ footer {
 
 <!-- ── NAV ──────────────────────────────────────── -->
 <nav>
-  <a href="#" class="nav-logo">dofek <em>v1.0</em></a>
+  <a href="#" class="nav-logo">dofek <em>v1.1</em></a>
   <div class="nav-links">
     <a href="#features">Features</a>
     <a href="#gui">Desktop</a>
@@ -567,7 +567,7 @@ footer {
   <div class="hero-text reveal">
     <div class="hero-badge">
       <span class="dot">●</span>
-      v1.0 — Windows 10 / 11 · MIT License
+      v1.1 — Windows 10 / 11 · Linux · MIT License
     </div>
     <h1>Your workstation deserves better than <span class="accent-cpu">Task Manager</span>.</h1>
     <p class="hero-sub">
@@ -578,7 +578,7 @@ footer {
     <div class="hero-ctas">
       <a href="https://github.com/AsafSaar/dofek/releases" target="_blank" rel="noopener" class="btn-primary">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
-        Download for Windows
+        Download (Windows · Linux)
       </a>
       <a href="https://github.com/AsafSaar/dofek" target="_blank" rel="noopener" class="btn-secondary">
         <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
@@ -868,7 +868,7 @@ footer {
     <div class="install-step reveal">
       <div class="step-num">01 — DOWNLOAD OR BUILD</div>
       <div class="step-title">Get the binary</div>
-      <div class="step-body">Grab the TUI or desktop app from GitHub Releases, or build either from source with the Rust stable toolchain and VS Build Tools (C++ workload).</div>
+      <div class="step-body">Grab the TUI or desktop app from GitHub Releases — Windows .msi, Linux .deb / .rpm / .AppImage. Or build from source with the Rust stable toolchain (plus VS Build Tools on Windows, or webkit2gtk + GTK headers on Linux).</div>
       <div class="step-code">git clone github.com/AsafSaar/dofek<br>cd dofek<br>cargo build --release <span style="color:var(--muted)"># TUI</span><br>cd gui &amp;&amp; cargo tauri build <span style="color:var(--muted)"># Desktop</span></div>
     </div>
     <div class="install-step reveal reveal-d1">
@@ -879,8 +879,8 @@ footer {
     </div>
     <div class="install-step reveal reveal-d2">
       <div class="step-num">03 — OPTIONAL</div>
-      <div class="step-title">LibreHardwareMonitor</div>
-      <div class="step-body">Run LHM as admin with the web server on port 8085. dofek auto-detects it and pulls CPU temperature and power draw — data that sysinfo can't provide on Windows. Also serves as GPU fallback for non-NVIDIA systems.</div>
+      <div class="step-title">CPU temperature on Windows</div>
+      <div class="step-body">Run <a href="https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/releases" target="_blank" rel="noopener" style="color:var(--cpu)">LibreHardwareMonitor</a> as admin with the web server on port 8085. dofek auto-detects it and pulls CPU temperature and power draw — data that sysinfo can't provide on Windows without elevation. Also serves as GPU fallback for non-NVIDIA systems. Linux skips this step entirely — CPU temps come straight from <code>/sys/class/hwmon</code>.</div>
     </div>
   </div>
   <a href="https://github.com/AsafSaar/dofek" target="_blank" rel="noopener" class="btn-primary" style="display:inline-flex;margin:0 auto">
@@ -923,7 +923,7 @@ footer {
 
 <!-- ── FOOTER ────────────────────────────────────── -->
 <footer>
-  <div class="footer-logo">dofek <em>v1.0</em></div>
+  <div class="footer-logo">dofek <em>v1.1</em></div>
   <div class="footer-meta">
     Built with Rust · Ratatui + Tauri · MIT License<br>
     © 2025–2026 Asaf Saar

--- a/website/plugins/index.html
+++ b/website/plugins/index.html
@@ -389,7 +389,7 @@
 <footer>
   <div>
     <span class="footer-logo">dofek</span>
-    <span style="font-size:11px;color:var(--muted);margin-left:12px">Plugin System v1.0</span>
+    <span style="font-size:11px;color:var(--muted);margin-left:12px">Plugin System v1.1</span>
   </div>
   <div class="footer-links">
     <a href="../index.html">Home</a>


### PR DESCRIPTION
## Summary

Fixes two more bugs that surfaced when the v1.1.0 release retry actually got past the Windows SHA256 step. Both are in the \`publish\` job I added in the Linux-support PR.

### Bug 1 — both downloads write to the same path

\`\`\`yaml
- uses: actions/download-artifact@v4
  with: { name: windows-build, path: artifacts }
- uses: actions/download-artifact@v4
  with: { name: linux-build,   path: artifacts }
\`\`\`

Each artifact bundle contains a \`SHA256SUMS.txt\`. Downloading both to the same directory means the second one silently overwrites the first — we'd ship checksums for one platform only.

### Bug 2 — the merge step deletes its own output

\`\`\`bash
cat SHA256SUMS*.txt > SHA256SUMS.combined.txt
rm -f SHA256SUMS.txt SHA256SUMS*.txt   # glob matches SHA256SUMS.combined.txt
mv SHA256SUMS.combined.txt SHA256SUMS.txt
\`\`\`

→ \`mv: cannot stat 'SHA256SUMS.combined.txt': No such file or directory\`

### Fix

Download each platform into its own directory (\`artifacts-win\`, \`artifacts-linux\`), copy non-checksum files into a clean \`artifacts/\` staging dir, and concatenate the two SHA256SUMS files explicitly — no globbing the output.

## Also bundled

v1.1 display-string bumps across the codebase (per the local \`dofek-version-bump\` skill), since they ship as part of v1.1 and were uncommitted on \`main\`:

- \`src/ui/ticker.rs\`, \`src/ui/about.rs\` — TUI version label
- \`gui/frontend/index.html\` — logo + About modal
- \`gui/docs/dofek-concept-v2.html\` — was on v0.7
- \`website/index.html\` — nav, hero badge, footer, JSON-LD (\`softwareVersion\` 0.8 → 1.1, \`operatingSystem\` adds Linux), all meta/OG/twitter descriptions, hero CTA, install-step copy (mentions .deb/.rpm/.AppImage; LHM step retitled and notes Linux skips it via \`/sys/class/hwmon\`)
- \`website/plugins/index.html\` — Plugin System v1.x label
- \`README.md\` — ASCII layout header + verify-checksum filename
- \`README-install.txt\` — full rewrite; dual-OS launch + config paths
- \`CLAUDE.md\` — \`Current Status\` line

## Test plan

- [x] CI lint+test on this PR (Windows + Linux).
- [ ] After merge: re-run release workflow_dispatch with \`tag=v1.1.0\`. All three jobs (build-windows, build-linux, release) should succeed; the resulting GitHub Release should contain \`SHA256SUMS.txt\` covering every Windows + Linux artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)