### PR TITLE
chore: add dev-gui.sh helper for Linux Tauri dev runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 !.claude/skills/
 dofek.toml
 website/node_modules/
+# Tauri-generated dev schema files (regenerated on every `cargo gui` run)
+/gui/gen/

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ cargo tui                          # Run TUI
 cargo gui                          # Run GUI (launches with hot-reload)
 ```
 
+The Tauri GUI declares `dofek-tui` as an `externalBin`, suffixed with the host target triple. If you've never run a release build, `cargo gui` will fail with `resource path '../target/release/dofek-tui-<triple>' doesn't exist`. Run the helper once to build the TUI and stage the suffixed copy:
+
+```bash
+./dev-gui.sh                       # builds dofek-tui release, stages it, runs cargo tauri dev
+```
+
+After that, `cargo gui` works on its own as long as the staged binary stays in place.
+
 **Release** (optimized, LTO + strip):
 
 ```bash

--- a/dev-gui.sh
+++ b/dev-gui.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# dev-gui.sh — Tauri dev server with the externalBin TUI binary staged.
+#
+# `cargo tauri dev` (the alias `cargo gui`) refuses to start until the
+# externalBin path declared in gui/tauri.conf.json exists, suffixed with the
+# host target triple. This script builds dofek-tui in release mode, copies it
+# with the right name, then runs the Tauri dev server.
+#
+# Usage: ./dev-gui.sh
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+TARGET_TRIPLE=$(rustc -vV | sed -n 's/^host: //p')
+case "$TARGET_TRIPLE" in
+    *windows*) EXT=".exe" ;;
+    *)         EXT=""     ;;
+esac
+
+echo "=== Building dofek-tui (release) ==="
+cargo build --release -p dofek --bin dofek-tui
+
+SRC="target/release/dofek-tui${EXT}"
+DST="target/release/dofek-tui-${TARGET_TRIPLE}${EXT}"
+echo "Staging ${SRC} → ${DST}"
+cp -f "$SRC" "$DST"
+
+echo "=== Starting Tauri dev server ==="
+cd gui
+exec cargo tauri dev


### PR DESCRIPTION
## Summary

\`cargo gui\` on a fresh clone fails at the Tauri build script with:

> resource path \`../target/release/dofek-tui-x86_64-unknown-linux-gnu\` doesn't exist

Tauri's \`externalBin\` in \`gui/tauri.conf.json\` references \`../target/release/dofek-tui\`, which Tauri then suffixes with the host target triple. Out of the box only the un-suffixed binary exists.

\`build-all.sh\` already does this staging for full release bundle builds. This adds a minimal \`./dev-gui.sh\` for the dev case: builds dofek-tui release, copies it with the right name, runs \`cargo tauri dev\`. README's Dev section points at it.

Also adds \`/gui/gen/\` to \`.gitignore\` — Tauri regenerates schema files there on every \`cargo gui\` run.

## Test plan

- [x] \`./dev-gui.sh\` on Ubuntu 24.04 stages \`target/release/dofek-tui-x86_64-unknown-linux-gnu\` and launches \`cargo tauri dev\` past the previous failure point.
- [x] CI lint+test on this PR (Windows + Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)