### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+# Dependabot keeps dependencies fresh and surfaces security advisories
+# automatically. Grouped by ecosystem, batched weekly so the volume stays
+# manageable.
+version: 2
+updates:
+  # Rust workspace (covers root, gui/, plugins/* via workspace members).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Website (Vercel) — currently only a package-lock for transitive scanning.
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "website"
+
+  # GitHub Actions versions in .github/workflows/*.yml
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly grouped updates for cargo (workspace incl. `gui/` and `plugins/*`), npm (`website/`), and github-actions across `.github/workflows`.
- Final piece of public-launch prep before flipping repo visibility.

## Test plan
- [x] CI green on the branch
- [ ] After merge, confirm Dependabot picks up the schedule (first PRs should appear within a week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)