### PR TITLE
docs: sync tech stack table with actual crate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,14 +582,14 @@ LHM fallback ──> GPU sensors (if NVML unavailable) ────────�
 | Component | Crate | Version |
 |-----------|-------|---------|
 | TUI framework | ratatui | 0.30 |
-| Terminal backend | crossterm | 0.28 |
-| System info | sysinfo | 0.38 |
+| Terminal backend | crossterm | 0.29 |
+| System info | sysinfo | 0.39 |
 | NVIDIA GPU | nvml-wrapper | 0.12 |
 | HTTP client | ureq | 2 |
-| Config | toml + clap | 0.8 / 4 |
+| Config | toml + clap | 1.1 / 4 |
 | Serialization | serde + serde_json | 1 |
-| Win32 API (Windows only) | windows | 0.61 |
-| POSIX signals (Unix only) | nix | 0.29 |
+| Win32 API (Windows only) | windows | 0.62 |
+| POSIX signals (Unix only) | nix | 0.31 |
 | Local time formatting | chrono | 0.4 |
 | Error handling | anyhow | 1 |
 | Logging | log + env_logger | 0.4 / 0.11 |


### PR DESCRIPTION
## What

The README tech stack table had drifted from `Cargo.toml` across five rows:

| Row | Was | Now | Source |
|---|---|---|---|
| crossterm | 0.28 | **0.29** | `Cargo.toml:27` |
| sysinfo | 0.38 | **0.39** | `Cargo.toml:44` |
| toml | 0.8 | **1.1** | `Cargo.toml:35` |
| windows | 0.61 | **0.62** | `Cargo.toml:65` |
| nix | 0.29 | **0.31** | `Cargo.toml:62` |

The other ten rows (ratatui, nvml-wrapper, ureq, serde, chrono, anyhow, log/env_logger, dirs, uuid, tauri) were checked and are still accurate.

## Relationship to #37

Supersedes #37, which fixed only the crossterm row and additionally changed the sample TUI output on README line 65 from `AMD Ryzen 7 7800X` to `7800X3D`.

That change is a regression. Line 65 is verbatim program output — the bottom strip truncates the CPU name to fit its column ([`src/ui/bottom_strip.rs:35`](https://github.com/AsafSaar/dofek/blob/main/src/ui/bottom_strip.rs#L35), `truncate(&app.data.cpu.name, area.width.saturating_sub(10))`), which is exactly why it differs from the untruncated ticker on line 49. "Fixing" it desyncs the README from what the TUI actually prints, and the three extra characters push the `|` column separator out of alignment with the four rows beneath it.

Docs-only change; no source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTbutVm12ZNgkoMFvcNYVM